### PR TITLE
default file current to .kxd file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v0.0.8 (October 25, 2023)
+* Fix for setting default as argument.
+* Changed the way kxd file current works to check `~/.kxd` file then default to `~/.kube/config`.
+
 ## v0.0.7 (October 23, 2023)
 * Added support for setting config names as argument.
 * Added list command to `kxd file` and `kxd ctx`.

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ kxd version
 To persist the set config when you open new terminal windows, you can add the following to your bash profile or zshrc.
 
 ```bash
-export KUBECONFIG=$(cat ~/.kxd)
+export KUBECONFIG=$(kxd file current)
 ```
 
 ### Show your set kubeconfig in your shell prompt

--- a/src/cmd/file.go
+++ b/src/cmd/file.go
@@ -107,14 +107,20 @@ func runGetCurrentConfig() error {
 	homeDir := utils.GetHomeDir()
 	kxdPath := filepath.Join(homeDir, ".kxd")
 
-	defaultKubeConfigPath := filepath.Join(homeDir, ".kube", "config")
+	// Default to KUBECONFIG env var then ~/.kube/config if .kxd config doesn't exist
+	defaultKubeConfigPath := utils.GetEnv("KUBECONFIG", filepath.Join(homeDir, ".kube", "config"))
 	configPath := defaultKubeConfigPath
 
+	// Check if .kxd file exists.
 	if _, err := os.Stat(kxdPath); !os.IsNotExist(err) {
 		content, _ := os.ReadFile(kxdPath)
 		trimmedContent := strings.TrimSpace(string(content))
+
+		// If .kxd file is not empty, determine the specified kubeconfig path.
 		if trimmedContent != "" {
 			specifiedConfigPath := filepath.Join(homeDir, ".kube", trimmedContent)
+
+			// If the specified kubeconfig exists, update the configPath.
 			if _, err := os.Stat(specifiedConfigPath); !os.IsNotExist(err) {
 				configPath = specifiedConfigPath
 			}

--- a/src/cmd/file.go
+++ b/src/cmd/file.go
@@ -8,6 +8,7 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"strings"
 )
 
 var fileCmd = &cobra.Command{
@@ -103,14 +104,28 @@ func runConfigSwitcher() error {
 }
 
 func runGetCurrentConfig() error {
-	kubeconfigPath := utils.GetEnv("KUBECONFIG", filepath.Join(utils.GetHomeDir(), ".kube/config"))
-	if _, err := os.Stat(kubeconfigPath); os.IsNotExist(err) {
-		log.Fatal("No current kubeconfig found.")
-	} else if err != nil {
-		log.Fatal(err)
-	} else {
-		fmt.Println(kubeconfigPath)
+	homeDir := utils.GetHomeDir()
+	kxdPath := filepath.Join(homeDir, ".kxd")
+
+	defaultKubeConfigPath := filepath.Join(homeDir, ".kube", "config")
+	configPath := defaultKubeConfigPath
+
+	if _, err := os.Stat(kxdPath); !os.IsNotExist(err) {
+		content, _ := os.ReadFile(kxdPath)
+		trimmedContent := strings.TrimSpace(string(content))
+		if trimmedContent != "" {
+			specifiedConfigPath := filepath.Join(homeDir, ".kube", trimmedContent)
+			if _, err := os.Stat(specifiedConfigPath); !os.IsNotExist(err) {
+				configPath = specifiedConfigPath
+			}
+		}
 	}
+
+	if _, err := os.Stat(configPath); os.IsNotExist(err) {
+		log.Fatal("Kubeconfig not found")
+	}
+
+	fmt.Println(configPath)
 	return nil
 }
 


### PR DESCRIPTION
`kxd file curent` was first checking for `KUBECONFIG` env var then falling back to `~/.kube/config`. This changes logic to.

1. use .kxd for kubeconfig if it exists
2. use KUBECONFIG if it is set
3. default to ~/.kube.config
