### PR TITLE
Fixed a crash when scrolling through an empty list, which occurred wh…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## v0.1.2 (UNRELEASED)
+* Fixed a crash when scrolling through an empty list, which occurred when searches returned no results.
+
 ## v0.1.1 (August, 1, 2024)
 * Adds circular scrolling #39.
 

--- a/go.mod
+++ b/go.mod
@@ -5,14 +5,14 @@ go 1.22.0
 toolchain go1.22.5
 
 require (
-	github.com/radiusmethod/promptui v0.10.0
+	github.com/radiusmethod/promptui v0.10.2
 	github.com/spf13/cobra v1.8.1
 	k8s.io/apimachinery v0.30.3
 	k8s.io/client-go v0.30.3
 )
 
 require (
-	github.com/chzyer/readline v1.5.0 // indirect
+	github.com/chzyer/readline v1.5.1 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/emicklei/go-restful/v3 v3.11.0 // indirect
 	github.com/go-logr/logr v1.4.1 // indirect
@@ -35,7 +35,7 @@ require (
 	github.com/spf13/pflag v1.0.5 // indirect
 	golang.org/x/net v0.23.0 // indirect
 	golang.org/x/oauth2 v0.10.0 // indirect
-	golang.org/x/sys v0.18.0 // indirect
+	golang.org/x/sys v0.24.0 // indirect
 	golang.org/x/term v0.18.0 // indirect
 	golang.org/x/text v0.14.0 // indirect
 	golang.org/x/time v0.3.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,10 @@
 github.com/chzyer/logex v1.2.0 h1:+eqR0HfOetur4tgnC8ftU5imRnhi4te+BadWS95c5AM=
 github.com/chzyer/logex v1.2.0/go.mod h1:9+9sk7u7pGNWYMkh0hdiL++6OeibzJccyQU4p4MedaY=
+github.com/chzyer/logex v1.2.1/go.mod h1:JLbx6lG2kDbNRFnfkgvh4eRJRPX1QCoOIWomwysCBrQ=
 github.com/chzyer/readline v1.5.0 h1:lSwwFrbNviGePhkewF1az4oLmcwqCZijQ2/Wi3BGHAI=
 github.com/chzyer/readline v1.5.0/go.mod h1:x22KAscuvRqlLoK9CsoYsmxoXZMMFVyOl86cAH8qUic=
+github.com/chzyer/readline v1.5.1 h1:upd/6fQk4src78LMRzh5vItIt361/o4uq553V8B5sGI=
+github.com/chzyer/readline v1.5.1/go.mod h1:Eh+b79XXUwfKfcPLepksvw2tcLE/Ct21YObkaSkeBlk=
 github.com/chzyer/test v0.0.0-20210722231415-061457976a23/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
 github.com/chzyer/test v1.0.0 h1:p3BQDXSxOhOG0P9z6/hGnII4LGiEPOYBhs8asl/fC04=
 github.com/chzyer/test v1.0.0/go.mod h1:2JlltgoNkt4TW/z9V/IzDdFaMTM2JPIi26O1pF38GC8=
@@ -73,6 +76,10 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/radiusmethod/promptui v0.10.0 h1:DOVHz6bT0mYj6/cjIjNFa1SqYJ6Eo8U9Rut/BTgNmmc=
 github.com/radiusmethod/promptui v0.10.0/go.mod h1:DYi97d3v31QmmuR4BEIT7NWh7xGweHGUCSMlM8LH7pY=
+github.com/radiusmethod/promptui v0.10.1 h1:aDL6O9fQIHcLEtV8qFfkRClDHF5wpO8VQBnSvUGXlUo=
+github.com/radiusmethod/promptui v0.10.1/go.mod h1:DYozY3lsgSlf+M+LXX4QF7/QY246KqP69zhdIvPBg+8=
+github.com/radiusmethod/promptui v0.10.2 h1:EsN8QTW/ZdUEUGnXjZmVn+at6P1WXTWvS9FLEInUpFc=
+github.com/radiusmethod/promptui v0.10.2/go.mod h1:DYozY3lsgSlf+M+LXX4QF7/QY246KqP69zhdIvPBg+8=
 github.com/rogpeppe/go-internal v1.10.0 h1:TMyTOH3F/DB16zRVcYyreMH6GnZZrwQVAoYjRBZyWFQ=
 github.com/rogpeppe/go-internal v1.10.0/go.mod h1:UQnix2H7Ngw/k4C5ijL5+65zddjncjaFoBhdsK/akog=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
@@ -114,6 +121,8 @@ golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20220310020820-b874c991c1a5/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.18.0 h1:DBdB3niSjOA/O0blCZBqDefyWNYveAYMNF1Wum0DYQ4=
 golang.org/x/sys v0.18.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
+golang.org/x/sys v0.24.0 h1:Twjiwq9dn6R1fQcyiK+wQyHWfaz/BJB+YIpzU/Cv3Xg=
+golang.org/x/sys v0.24.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 golang.org/x/term v0.18.0 h1:FcHjZXDMxI8mM3nwhX9HlKop4C0YQvCVCdwYl2wOtE8=
 golang.org/x/term v0.18.0/go.mod h1:ILwASektA3OnRv7amZ1xhE/KTR+u50pbXfZ03+6Nx58=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=


### PR DESCRIPTION
…en searches returned no results

```
9:01:02 › kxd
Kubeconfig Switcher
Search: twa█
Choose a config?

No results



panic: runtime error: index out of range [0] with length 0

goroutine 9 [running]:
github.com/radiusmethod/promptui/list.(*List).Index(...)
	/Users/pjoyce/Library/Caches/Homebrew/go_mod_cache/pkg/mod/github.com/radiusmethod/promptui@v0.10.0/list/list.go:204
github.com/radiusmethod/promptui.(*Select).innerRun.func1({0x81ced40, 0x0, 0x0}, 0xc0001a6d10?, 0x10)
	/Users/pjoyce/Library/Caches/Homebrew/go_mod_cache/pkg/mod/github.com/radiusmethod/promptui@v0.10.0/select.go:294 +0x132d
github.com/chzyer/readline.(*DumpListener).OnChange(0xc0001a6c80?, {0x81ced40?, 0x70e3cb7?, 0x2?}, 0xc000205f70?, 0x1?)
	/Users/pjoyce/Library/Caches/Homebrew/go_mod_cache/pkg/mod/github.com/chzyer/readline@v1.5.0/operation.go:516 +0x2b
github.com/chzyer/readline.(*Operation).ioloop(0xc0001e8070)
	/Users/pjoyce/Library/Caches/Homebrew/go_mod_cache/pkg/mod/github.com/chzyer/readline@v1.5.0/operation.go:339 +0x1ae5
created by github.com/chzyer/readline.NewOperation in goroutine 1
	/Users/pjoyce/Library/Caches/Homebrew/go_mod_cache/pkg/mod/github.com/chzyer/readline@v1.5.0/operation.go:88 +0x2c6
```